### PR TITLE
Make name and datatype optional for Variables and Constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 |-------------------|----------------------|------------------|----------------|
 | [![Build Status](https://circleci.com/gh/Arafatk/tensorflow.rb.svg?style=shield)](https://circleci.com/gh/Arafatk/tensorflow.rb) | _Not Configured_ | _Not Configured_ |
 
-[![Code Climate](https://codeclimate.com/github/Arafatk/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/Arafatk/tensorflow.rb)
+[![Code Climate](https://codeclimate.com/github/somaticio/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/somaticio/tensorflow.rb)
 [![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Inline docs](https://inch-ci.org/github/Arafatk/tensorflow.rb.svg?branch=master)](https://inch-ci.org/github/Arafatk/tensorflow.rb)
+[![Inline docs](https://inch-ci.org/github/somaticio/tensorflow.rb.svg?branch=master)](https://inch-ci.org/github/somaticio/tensorflow.rb)
 ## Documentation
-Everything is at [RubyDoc](http://www.rubydoc.info/github/Arafatk/tensorflow.rb).
+Everything is at [RubyDoc](http://www.rubydoc.info/github/somaticio/tensorflow.rb).
 You can also generate docs by
 ```bundle exec rake doc```.
 
@@ -76,7 +76,7 @@ export LIBRARY_PATH=$PATH:/usr/local/lib (may be required)
 
 Clone and install this Ruby API:
 ```
-git clone https://github.com/Arafatk/tensorflow.rb.git
+git clone https://github.com/somaticio/tensorflow.rb.git
 cd tensorflow.rb/ext/sciruby/tensorflow_c
 ruby extconf.rb
 make

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 
 |  **`Linux CPU`**   |  **`Linux GPU PIP`** | **`Mac OS CPU`** |
 |-------------------|----------------------|------------------|----------------|
-| [![Build Status](https://circleci.com/gh/Arafatk/tensorflow.rb.svg?style=shield)](https://circleci.com/gh/Arafatk/tensorflow.rb) | _Not Configured_ | _Not Configured_ |
+| [![Build Status](https://circleci.com/gh/somaticio/tensorflow.rb.svg?style=shield)](https://circleci.com/gh/somaticio/tensorflow.rb) | _Not Configured_ | _Not Configured_ |
 
 [![Code Climate](https://codeclimate.com/github/somaticio/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/somaticio/tensorflow.rb)
 [![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 | [![Build Status](https://circleci.com/gh/somaticio/tensorflow.rb.svg?style=shield)](https://circleci.com/gh/somaticio/tensorflow.rb) | _Not Configured_ | _Not Configured_ |
 
 [![Code Climate](https://codeclimate.com/github/somaticio/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/somaticio/tensorflow.rb)
-[![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/tensorflowrb/Lobby](https://badges.gitter.im/tensorflowrb/Lobby.svg)](https://gitter.im/tensorflowrb/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Inline docs](https://inch-ci.org/github/somaticio/tensorflow.rb.svg?branch=master)](https://inch-ci.org/github/somaticio/tensorflow.rb)
 ## Documentation
 Everything is at [RubyDoc](http://www.rubydoc.info/github/somaticio/tensorflow.rb).

--- a/spec/constant_spec.rb
+++ b/spec/constant_spec.rb
@@ -5,41 +5,74 @@ describe 'Constants' do
 
   let(:session) { Tensorflow::Session.new }
   let(:result) { session.run(nil, ["output"], nil) }
-  before do
-    define_op
-    graph.graph_def_raw = Tensorflow::GraphDef.encode(graph.graph_def)
-    session.extend_graph(graph)
-  end
+
 
   subject { result[0] }
 
-  context 'add' do
-    let(:input1) { graph.constant("const1", [Complex(2,2), Complex(2,34)], :complex) }
-    let(:input2) { graph.constant("const2", [Complex(2,2), Complex(-32,22)], :complex) }
-    let(:define_op) { graph.define_op("Add",'output', [input1, input2],"",nil) }
-
-    it { is_expected.to all_be_close([Complex(4.0,4.0), Complex(-30.0,56.0)]) }
+  it "sets the constant name when it is specified" do
+    no_name1 = graph.constant([1, 2, 3],  name: "testing_names")
+    expect(no_name1.definition.name).to eq("testing_names")
   end
 
-  context 'sub' do
-    # If we could use the same inputs for all tests, it would be even more DRY
-    let(:input1) { graph.constant("const1", [634,432], :float64) }
-    let(:input2) { graph.constant("const2", [332,332], :float64) }
-    let(:define_op) { graph.define_op("Sub",'output', [input1, input2],"",nil) }
-
-    it { is_expected.to all_be_close([302.0,100.0]) }
+  it "sets a default name if none is specified" do
+    no_name = graph.constant([1, 2, 3])
+    expect(no_name.definition.name).to eq("Constant:0")
   end
 
-  describe 'retrieve constants' do
-    let(:input1) { graph.constant("const1", [634,432], :float64) }
-    let(:input2) { graph.constant("const2", [332,332], :float64) }
-    let(:define_op) { graph.define_op("Sub",'output', [input1, input2],"",nil) }
+  it "increments the default constant name for each unnamed constant" do
+    no_name1 = graph.constant([1, 2, 3])
+    no_name2 = graph.constant([4, 5, 6])
+    expect(no_name1.definition.name).to eq("Constant:0")
+    expect(no_name2.definition.name).to eq("Constant:1")
+  end
 
-    it 'returns all constants' do
-      expect(graph.constants.keys).to match_array [
-        input1.definition.name,
-        input2.definition.name
-      ]
+  it "sets data type when it is specified" do
+    no_type = graph.constant([1, 2, 3], dtype: :int32)
+    dtype = graph.type_to_enum(no_type.definition.attr["dtype"].type)
+    expect(dtype).to eq(Tensorflow::TF_INT32)
+  end
+
+  it "infers data type based on initial data if not explicitly specified" do
+    no_type = graph.constant([1, 2, 3])
+    dtype = graph.type_to_enum(no_type.definition.attr["dtype"].type)
+    expect(dtype).to eq(Tensorflow::TF_INT64)
+  end
+
+  describe "operations on constants" do
+    before do
+      define_op
+      graph.graph_def_raw = Tensorflow::GraphDef.encode(graph.graph_def)
+      session.extend_graph(graph)
+    end
+
+    describe "addition" do
+      let(:input1) { graph.constant([Complex(2,2), Complex(2,34)], name: "const1", dtype: :complex) }
+      let(:input2) { graph.constant([Complex(2,2), Complex(-32,22)], name: "const2", dtype: :complex) }
+      let(:define_op) { graph.define_op("Add",'output', [input1, input2],"",nil) }
+
+      it { is_expected.to all_be_close([Complex(4.0,4.0), Complex(-30.0,56.0)]) }
+    end
+
+    describe "subtraction" do
+      # If we could use the same inputs for all tests, it would be even more DRY
+      let(:input1) { graph.constant([634,432], name: "const1", dtype: :float64) }
+      let(:input2) { graph.constant([332,332], name: "const2", dtype: :float64) }
+      let(:define_op) { graph.define_op("Sub",'output', [input1, input2],"",nil) }
+
+      it { is_expected.to all_be_close([302.0,100.0]) }
+    end
+
+    describe "retrieval" do
+      let(:input1) { graph.constant([634,432], name: "const1", dtype: :float64) }
+      let(:input2) { graph.constant([332,332], name: "const2", dtype: :float64) }
+      let(:define_op) { graph.define_op("Sub",'output', [input1, input2],"",nil) }
+
+      it "returns all constants" do
+        expect(graph.constants.keys).to match_array [
+          input1.definition.name,
+          input2.definition.name
+        ]
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,7 @@ require 'pry'
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.dirname(__FILE__) + "/support/*.rb"].each {|f| require f }
+
+RSpec.configure do |c|
+  c.example_status_persistence_file_path = "examples.txt"
+end

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -1,10 +1,49 @@
 require 'spec_helper'
 
 describe "Variable" do
-    it "Subtract Tensors" do
-    graph = Tensorflow::Graph.new
-    input1 = graph.variable("input1", [343,32], :int32)
-    input2 = graph.constant("input2", [33,42], :int32)
+  let(:graph) { Tensorflow::Graph.new }
+
+  it "sets the variable name when it is specified" do
+    no_name1 = graph.variable([1, 2, 3],  name: "testing_names")
+    expect(no_name1.ref.name).to eq("testing_names")
+  end
+
+  it "sets a default name if none is specified" do
+    no_name = graph.variable([1, 2, 3])
+    expect(no_name.ref.name).to eq("Variable:0")
+  end
+
+  it "increments the default variable name for each unnamed variable" do
+    no_name1 = graph.variable([1, 2, 3])
+    no_name2 = graph.variable([4, 5, 6])
+    expect(no_name1.ref.name).to eq("Variable:0")
+    expect(no_name2.ref.name).to eq("Variable:1")
+  end
+
+  it "increments variable and constant names separately" do
+    variable0 = graph.variable([0])
+    constant0 = graph.constant([0])
+    variable1 = graph.variable([1])
+    expect(variable0.ref.name).to eq("Variable:0")
+    expect(constant0.definition.name).to eq("Constant:0")
+    expect(variable1.ref.name).to eq("Variable:1")
+  end
+
+  it "sets data type when it is specified" do
+    no_type = graph.variable([1, 2, 3], dtype: :int32)
+    dtype = graph.type_to_enum(no_type.ref.attr["dtype"].type)
+    expect(dtype).to eq(Tensorflow::TF_INT32)
+  end
+
+  it "infers data type based on initial data if not explicitly specified" do
+    no_type = graph.variable([1, 2, 3])
+    dtype = graph.type_to_enum(no_type.ref.attr["dtype"].type)
+    expect(dtype).to eq(Tensorflow::TF_INT64)
+  end
+
+  it "subtracts tensors across multiple sessions" do
+    input1 = graph.variable([343,32], dtype: :int32, name: "input1")
+    input2 = graph.constant([33,42], dtype: :int32, name: "input2")
     add = graph.define_op("Sub",'add_tensors', [input1, input2],"",nil)
     graph.define_op("Assign",'assign_inp1', [input1, add],"",nil)
     graph.intialize_variables
@@ -16,4 +55,6 @@ describe "Variable" do
     result = session.run(nil, ["input1"], ["assign_inp1"])
     expect(result[0]).to match_array([244, -94])
   end
+
+
 end


### PR DESCRIPTION
The Python API allows name and datatype as optional parameters when
creating a variable or a constant, making these declarations much
more concise in typical cases. This changes the Ruby API to take
those as optional parameters to more closely mirror the Python.