### PR TITLE
update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tensorflow.rb
 
 ## Description
-This repository contains Ruby API for utilizing [TensorFlow](https://github.com/tensorflow/tensorflow).
+This repository contains a Ruby API for utilizing [TensorFlow](https://github.com/tensorflow/tensorflow).
 
 |  **`Linux CPU`**   |  **`Linux GPU PIP`** | **`Mac OS CPU`** |
 |-------------------|----------------------|------------------|----------------|
@@ -15,8 +15,11 @@ Everything is at [RubyDoc](http://www.rubydoc.info/github/somaticio/tensorflow.r
 You can also generate docs by
 ```bundle exec rake doc```.
 
+## Installation
 
-## Docker
+### Docker
+
+It's easiest to get started using the prebuilt Docker container.
 
 Launch:
 
@@ -33,24 +36,27 @@ bundle exec rspec
 
 For details, see: https://hub.docker.com/r/nethsix/ruby-tensorflow-ubuntu/
 
-## Dependencies
+### Outside of Docker
 
-### Explicit Install
+Alternatively, you can install outside of a Docker container by following
+the following steps.
+
+#### Explicit dependencies
 
 - [Bazel](http://www.bazel.io/docs/install.html)
 - [TensorFlow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/g3doc/get_started/os_setup.md)
 - [Swig](http://www.swig.org/download.html)
 
-### Implicit Install (No Action Required)
+#### Implicit dependencies (No Action Required)
 
 - [Google-Protoc gem](https://github.com/google/protobuf/tree/master/ruby) ( for installation do  ```gem install google-protoc --pre ```)
 - [Protobuf](https://github.com/google/protobuf)
 
-## Installation
+#### Installation
 
-All the dependencies mentioned above must be installed in your system before you proceed further.   
+All the dependencies mentioned above must be installed in your system before you proceed further.
 
-### Clone and Install TensorFlow
+#### Clone and Install TensorFlow
 
 This package depends on the TensorFlow shared libraries, in order to compile
 these libraries do the following:
@@ -72,7 +78,7 @@ sudo cp bazel-bin/tensorflow/libtensorflow.so /usr/local/lib
 export LIBRARY_PATH=$PATH:/usr/local/lib (may be required)
 ```
 
-### Install `tensorflow.rb`
+#### Install `tensorflow.rb`
 
 Clone and install this Ruby API:
 ```
@@ -86,7 +92,7 @@ bundle exec rake install
 ```
 The last command is for installing the gem.
 
-### Run tests and verify install
+#### Run tests and verify install
 ```
 bundle exec rake spec
 ```

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 |-------------------|----------------------|------------------|----------------|
 | [![Build Status](https://circleci.com/gh/Arafatk/tensorflow.rb.svg?style=shield)](https://circleci.com/gh/Arafatk/tensorflow.rb) | _Not Configured_ | _Not Configured_ |
 
-[![Code Climate](https://codeclimate.com/github/Arafatk/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/Arafatk/tensorflow.rb)
+[![Code Climate](https://codeclimate.com/github/somaticio/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/somaticio/tensorflow.rb)
 [![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Inline docs](https://inch-ci.org/github/Arafatk/tensorflow.rb.svg?branch=master)](https://inch-ci.org/github/Arafatk/tensorflow.rb)
+[![Inline docs](https://inch-ci.org/github/somaticio/tensorflow.rb.svg?branch=master)](https://inch-ci.org/github/somaticio/tensorflow.rb)
 ## Documentation
-Everything is at [RubyDoc](http://www.rubydoc.info/github/Arafatk/tensorflow.rb).
+Everything is at [RubyDoc](http://www.rubydoc.info/github/somaticio/tensorflow.rb).
 You can also generate docs by
 ```bundle exec rake doc```.
 
@@ -76,7 +76,7 @@ export LIBRARY_PATH=$PATH:/usr/local/lib (may be required)
 
 Clone and install this Ruby API:
 ```
-git clone https://github.com/Arafatk/tensorflow.rb.git
+git clone https://github.com/somaticio/tensorflow.rb.git
 cd tensorflow.rb/ext/sciruby/tensorflow_c
 ruby extconf.rb
 make

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 
 |  **`Linux CPU`**   |  **`Linux GPU PIP`** | **`Mac OS CPU`** |
 |-------------------|----------------------|------------------|----------------|
-| [![Build Status](https://circleci.com/gh/Arafatk/tensorflow.rb.svg?style=shield)](https://circleci.com/gh/Arafatk/tensorflow.rb) | _Not Configured_ | _Not Configured_ |
+| [![Build Status](https://circleci.com/gh/somaticio/tensorflow.rb.svg?style=shield)](https://circleci.com/gh/somaticio/tensorflow.rb) | _Not Configured_ | _Not Configured_ |
 
 [![Code Climate](https://codeclimate.com/github/somaticio/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/somaticio/tensorflow.rb)
 [![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 | [![Build Status](https://circleci.com/gh/somaticio/tensorflow.rb.svg?style=shield)](https://circleci.com/gh/somaticio/tensorflow.rb) | _Not Configured_ | _Not Configured_ |
 
 [![Code Climate](https://codeclimate.com/github/somaticio/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/somaticio/tensorflow.rb)
-[![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/tensorflowrb/Lobby](https://badges.gitter.im/tensorflowrb/Lobby.svg)](https://gitter.im/tensorflowrb/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Inline docs](https://inch-ci.org/github/somaticio/tensorflow.rb.svg?branch=master)](https://inch-ci.org/github/somaticio/tensorflow.rb)
 ## Documentation
 Everything is at [RubyDoc](http://www.rubydoc.info/github/somaticio/tensorflow.rb).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,18 +9,19 @@ This document describes the roadmap for `tensflow.rb.`
 ## Simpler things to get started:
 
 - Polish the README based on your experiences on setting up the project, so it becomes easier for the next to join.
-- Add any missing specs you see, e.g. `Session#ruby_array_to_c` and the likes. Some of the methods in Graph, Session, Tensor should probably also be private if only called from within the class. If not, they must be tested.
+- Add any missing specs you see. Some of the methods in Graph, Session, Tensor should probably also be private if only called from within the class. If not, they must be tested.
 - Similar to 2. above, several methods could be cleaned up, and be written more ruby like (e.g. no `()` if no args and prefer `key: :value` over `:key => :value`.
 
 ## More advanced/new features:
 
 - [ ] Look at the [Basic Usage tutorial](https://www.tensorflow.org/versions/r0.9/get_started/index.html). What are we missing to be able to complete this?
-  - [ ] `tf.Variable`, please look at the pull request [here](https://github.com/Arafatk/tensorflow.rb/pull/32).
-  - [ ] `tf.Constant`, please look at the pull request [here](https://github.com/Arafatk/tensorflow.rb/pull/32).
+  - [x] `tf.Variable`, please look at the pull request [here](https://github.com/Arafatk/tensorflow.rb/pull/32).
+  - [x] `tf.Constant`, please look at the pull request [here](https://github.com/Arafatk/tensorflow.rb/pull/32).
   - [ ] `tf.random_uniform`
   - [ ] `tf.zeros`
   - [ ] `tf.reduce_mean`
   - [ ] `tf.train.GradientDescentOptimizer`
+  - [ ] Default graph support, to avoid the need for explicit graph creation
   - [ ] A better API for Tensorflow Math ops
   - [ ] A blog explaining how to use google protobuf to make graphs in ruby itself and then run them. This will be released soon.
 


### PR DESCRIPTION
Just some minor tweaks to the Readme and Roadmap, to make it slightly more accessible for new users/contributors. The only really substantive change is adding support for [default graphs](https://www.tensorflow.org/versions/r0.10/api_docs/python/framework.html#get_default_graph) to the roadmap.

Let me know if you think these changes make sense @Arafatk! Also I would be happy to work on default graph support if you agree that that is worth having. (Technically that's necessary for the basic usage tutorial, and I think it's a pretty important convenience for new users)