### PR TITLE
Fix default op-naming, tf.zeros, and compliant tf.constant

### DIFF
--- a/lib/tensorflow/graph.rb
+++ b/lib/tensorflow/graph.rb
@@ -121,8 +121,8 @@ class Tensorflow::Graph
   # Creates a constant Tensor that is added to the graph with a specified name.
   # Official documentation of {tf.constant}[https://www.tensorflow.org/versions/r0.9/api_docs/python/constant_op.html#constant].
   #
-  def constant(data, dtype: nil, name: nil)
-    tensor = Tensorflow::Tensor.new(data, dtype)
+  def constant(value, dtype: nil, shape: nil, name: nil)
+    tensor = Tensorflow::Tensor.new(value, dtype)
     name ||= default_name("Constant")
     constants[name] = tensor
     define_op("Const", name, nil, "", {
@@ -224,7 +224,7 @@ class Tensorflow::Graph
   # Returns a default name for a new variable or constant.
   # The name increments for each one created: Variable:0, Variable:1, and so on.
   def default_name(type)
-    name = "#{type}:#{@number_of_defaults_created[type]}"
+    name = "#{type}_#{@number_of_defaults_created[type]}"
     @number_of_defaults_created[type] += 1
     name
   end

--- a/lib/tensorflow/tensor.rb
+++ b/lib/tensorflow/tensor.rb
@@ -1,12 +1,12 @@
 # Tensor is an n-dimensional array or list which represents a value produced by an Operation.
 # A tensor has a rank, and a shape.
-# A Tensor is a symbolic handle to one of the outputs of an Operation. It does not hold the values of that 
+# A Tensor is a symbolic handle to one of the outputs of an Operation. It does not hold the values of that
 # operation's output, but instead provides a means of computing those values in a TensorFlow Session.
 # Official documentation of {tensor}[https://www.tensorflow.org/versions/r0.9/api_docs/python/framework.html#Tensor].
 # This class has two primary purposes:
 # * *Description* :
-#   - A Tensor can be passed as an input to another Operation. This builds a dataflow connection between 
-#   operations, which enables TensorFlow to execute an entire Graph that represents a large, multi-step 
+#   - A Tensor can be passed as an input to another Operation. This builds a dataflow connection between
+#   operations, which enables TensorFlow to execute an entire Graph that represents a large, multi-step
 #   computation.
 #   - After the graph has been launched in a session, the value of the Tensor can be computed by passing it to
 #   a Session.
@@ -42,14 +42,16 @@ class Tensorflow::Tensor
   #  Returns the shape of the Tensor in Ruby protocol buffers.(To be used later with ops).
 
   def initialize(data, type = nil)
-    self.dimensions = dimension_finder(data)  if data.is_a?(Array) 
-    raise("Incorrect dimensions specified in the input.") if self.dimensions == nil && data.is_a?(Array) 
+    self.dimensions = dimension_finder(data) if data.is_a?(Array)
+    raise("Incorrect dimensions specified in the input.") if self.dimensions == nil && data.is_a?(Array)
     self.rank = 0
     self.rank = self.dimensions.size if data.is_a?(Array)
     self.tensor_shape_proto = shape_proto(self.dimensions) if self.dimensions.is_a?(Array)
     self.element_type = set_type(type) if type != nil
     self.element_type = find_type(data) if type == nil
-    raise ("Multi-dimensional tensor not supported for string data type.") if self.dimensions.length > 1 and self.type_num == Tensorflow::TF_STRING
+    if dimensions.length > 1 && type_num == Tensorflow::TF_STRING
+      raise ("Multi-dimensional tensor not supported for string data type.")
+    end
     self.flatten = data.flatten
     self.tensor_data = ruby_array_to_c(self.flatten, self.type_num)
     self.dimension_data = ruby_array_to_c(self.dimensions, Tensorflow::TF_INT64)
@@ -103,7 +105,7 @@ class Tensorflow::Tensor
   end
 
   #
-  # Recursively finds the dimensions of the input array. 
+  # Recursively finds the dimensions of the input array.
   #
   # * *Returns* :
   #   - Dimension array (If the input is an n - dimensional matrix.)
@@ -117,9 +119,9 @@ class Tensorflow::Tensor
       [array.size]
     end
   end
-  
+
   #
-  # Converts a give ruby array to C array (using SWIG) by detecting the data type automatically. 
+  # Converts a give ruby array to C array (using SWIG) by detecting the data type automatically.
   # Design decision needs to be made regarding this so the all the data types are supported.
   # Currently Integer(Ruby) is converted to long long(C) and Float(Ruby) is converted double(C).
   #
@@ -173,7 +175,7 @@ class Tensorflow::Tensor
   end
 
   #
-  # Converts a give ruby array to C array (using SWIG) by detecting the data type automatically. 
+  # Converts a give ruby array to C array (using SWIG) by detecting the data type automatically.
   # Design decision needs to be made regarding this so the all the data types are supported.
   # Currently Integer(Ruby) is converted to long long(C) and Float(Ruby) is converted double(C).
   #

--- a/spec/constant_spec.rb
+++ b/spec/constant_spec.rb
@@ -1,78 +1,90 @@
 require 'spec_helper'
 
 describe 'Constants' do
-  let(:graph) { Tensorflow::Graph.new }
-
+  let!(:graph) { Tensorflow::Graph.new }
   let(:session) { Tensorflow::Session.new }
   let(:result) { session.run(nil, ["output"], nil) }
 
-
   subject { result[0] }
 
-  it "sets the constant name when it is specified" do
-    no_name1 = graph.constant([1, 2, 3],  name: "testing_names")
-    expect(no_name1.definition.name).to eq("testing_names")
-  end
-
-  it "sets a default name if none is specified" do
-    no_name = graph.constant([1, 2, 3])
-    expect(no_name.definition.name).to eq("Constant:0")
-  end
-
-  it "increments the default constant name for each unnamed constant" do
-    no_name1 = graph.constant([1, 2, 3])
-    no_name2 = graph.constant([4, 5, 6])
-    expect(no_name1.definition.name).to eq("Constant:0")
-    expect(no_name2.definition.name).to eq("Constant:1")
-  end
-
-  it "sets data type when it is specified" do
-    no_type = graph.constant([1, 2, 3], dtype: :int32)
-    dtype = graph.type_to_enum(no_type.definition.attr["dtype"].type)
-    expect(dtype).to eq(Tensorflow::TF_INT32)
-  end
-
-  it "infers data type based on initial data if not explicitly specified" do
-    no_type = graph.constant([1, 2, 3])
-    dtype = graph.type_to_enum(no_type.definition.attr["dtype"].type)
-    expect(dtype).to eq(Tensorflow::TF_INT64)
-  end
-
-  describe "operations on constants" do
-    before do
-      define_op
-      graph.graph_def_raw = Tensorflow::GraphDef.encode(graph.graph_def)
-      session.extend_graph(graph)
+  describe 'name' do
+    it "sets the constant name when it is specified" do
+      no_name1 = graph.constant([1, 2, 3], name: "testing_names")
+      expect(no_name1.definition.name).to eq("testing_names")
     end
 
-    describe "addition" do
-      let(:input1) { graph.constant([Complex(2,2), Complex(2,34)], name: "const1", dtype: :complex) }
-      let(:input2) { graph.constant([Complex(2,2), Complex(-32,22)], name: "const2", dtype: :complex) }
-      let(:define_op) { graph.define_op("Add",'output', [input1, input2],"",nil) }
+    it "sets a default name if none is specified" do
+      no_name = graph.constant([1, 2, 3])
+      expect(no_name.definition.name).to eq("Constant:0")
+    end
+
+    it "increments the default constant name for each unnamed constant" do
+      no_name1 = graph.constant([1, 2, 3])
+      no_name2 = graph.constant([4, 5, 6])
+      expect(no_name1.definition.name).to eq("Constant:0")
+      expect(no_name2.definition.name).to eq("Constant:1")
+    end
+  end
+
+  describe 'type' do
+    context 'explicit type' do
+      it "sets data type when it is specified" do
+        no_type = graph.constant([1, 2, 3], dtype: :int32)
+        dtype = graph.type_to_enum(no_type.definition.attr["dtype"].type)
+        expect(dtype).to eq(Tensorflow::TF_INT32)
+      end
+    end
+
+    context 'inferred type' do
+      it 'infers data type based on initial data if not explicitly specified' do
+        no_type = graph.constant([1, 2, 3], name: 'no_type')
+        dtype = graph.type_to_enum(no_type.definition.attr['dtype'].type)
+        expect(dtype).to eq(Tensorflow::TF_INT64)
+        graph.graph_def_raw = Tensorflow::GraphDef.encode(graph.graph_def)
+        session.extend_graph(graph)
+        result = session.run(nil, ['no_type'], nil)
+        expect(result[0]).to match_array([1, 2, 3])
+      end
+    end
+  end
+
+  describe 'operations on constants' do
+    context 'real numbers' do
+      let(:input1) { graph.constant([634, 432], name: 'const1', dtype: :float64) }
+      let(:input2) { graph.constant([332, 332], name: 'const2', dtype: :float64) }
+      let!(:define_op) do
+        graph.define_op('Sub', 'output', [input1, input2], '', nil)
+      end
+      before do
+        graph.graph_def_raw = Tensorflow::GraphDef.encode(graph.graph_def)
+        session.extend_graph(graph)
+      end
+
+      it { is_expected.to all_be_close([302.0, 100.0]) }
+
+      describe 'retrieval' do
+        it 'returns all constants' do
+          expect(graph.constants.keys).to match_array [
+            input1.definition.name,
+            input2.definition.name
+          ]
+        end
+      end
+    end
+
+    context 'complex numbers' do
+      let(:input1) { graph.constant([Complex(2,2), Complex(2,34)], name: 'const1', dtype: :complex) }
+      let(:input2) { graph.constant([Complex(2,2), Complex(-32,22)], name: 'const2', dtype: :complex) }
+      let!(:define_op) do
+        graph.define_op('Add', 'output', [input1, input2], '', nil)
+      end
+
+      before do
+        graph.graph_def_raw = Tensorflow::GraphDef.encode(graph.graph_def)
+        session.extend_graph(graph)
+      end
 
       it { is_expected.to all_be_close([Complex(4.0,4.0), Complex(-30.0,56.0)]) }
-    end
-
-    describe "subtraction" do
-      # If we could use the same inputs for all tests, it would be even more DRY
-      let(:input1) { graph.constant([634,432], name: "const1", dtype: :float64) }
-      let(:input2) { graph.constant([332,332], name: "const2", dtype: :float64) }
-      let(:define_op) { graph.define_op("Sub",'output', [input1, input2],"",nil) }
-
-      it { is_expected.to all_be_close([302.0,100.0]) }
-    end
-
-    describe "retrieval" do
-      let(:input1) { graph.constant([634,432], name: "const1", dtype: :float64) }
-      let(:input2) { graph.constant([332,332], name: "const2", dtype: :float64) }
-      let(:define_op) { graph.define_op("Sub",'output', [input1, input2],"",nil) }
-
-      it "returns all constants" do
-        expect(graph.constants.keys).to match_array [
-          input1.definition.name,
-          input2.definition.name
-        ]
-      end
     end
   end
 end

--- a/spec/constant_spec.rb
+++ b/spec/constant_spec.rb
@@ -32,15 +32,18 @@ describe 'Constants' do
   end
 
   describe 'type' do
-    context 'explicit type' do
+    context 'explicit' do
+      let(:with_type) { graph.constant([1, 2, 3], dtype: :int32) }
+
       it 'sets data type when it is specified' do
-        no_type = graph.constant([1, 2, 3], dtype: :int32)
-        dtype = graph.type_to_enum(no_type.definition.attr['dtype'].type)
+        dtype = graph.type_to_enum(
+          with_type.definition.attr['dtype'].type)
+
         expect(dtype).to eq(Tensorflow::TF_INT32)
       end
     end
 
-    context 'inferred type' do
+    context 'inferred' do
       let!(:no_type) { graph.constant([1, 2, 3], name: 'output') }
 
       it 'infers data type' do

--- a/spec/constant_spec.rb
+++ b/spec/constant_spec.rb
@@ -20,19 +20,33 @@ describe 'Constants' do
 
     it 'sets a default name if none is specified' do
       no_name = graph.constant([1, 2, 3])
-      expect(no_name.definition.name).to eq('Constant:0')
+      expect(no_name.definition.name).to eq('Constant_0')
     end
 
     it 'increments the default constant name for each unnamed constant' do
       no_name1 = graph.constant([1, 2, 3])
       no_name2 = graph.constant([4, 5, 6])
-      expect(no_name1.definition.name).to eq('Constant:0')
-      expect(no_name2.definition.name).to eq('Constant:1')
+      expect(no_name1.definition.name).to eq('Constant_0')
+      expect(no_name2.definition.name).to eq('Constant_1')
     end
   end
 
-  describe 'type' do
-    context 'explicit' do
+  describe 'creating and fetching on graph' do
+    context 'all inferred' do
+      let!(:list) { graph.constant([8, 7, 4]) }
+      let(:result1) do
+        graph.graph_def_raw = Tensorflow::GraphDef.encode(graph.graph_def)
+        session.extend_graph(graph)
+
+        session.run(nil, ['Constant_0'], nil)
+      end
+
+      it 'creates proper tensor' do
+        expect(result1[0]).to match_array([8, 7, 4])
+      end
+    end
+
+    context 'explicit type' do
       let(:with_type) { graph.constant([1, 2, 3], dtype: :int32) }
 
       it 'sets data type when it is specified' do
@@ -43,7 +57,7 @@ describe 'Constants' do
       end
     end
 
-    context 'inferred' do
+    context 'inferred type' do
       let!(:no_type) { graph.constant([1, 2, 3], name: 'output') }
 
       it 'infers data type' do

--- a/spec/tensor_spec.rb
+++ b/spec/tensor_spec.rb
@@ -1,21 +1,24 @@
 require 'spec_helper'
-describe "Tensorflow::Tensor" do 
-  it "Should Give correct results for adding two tensors." do 
-    input1 = Tensorflow::Tensor.new([[1,2],[3,4]])
-    input2 = Tensorflow::Tensor.new([[7,3],[4,21]])
-    graph = Tensorflow::Graph.new
-    graph.read(File.dirname(__FILE__)+'/example_graphs/example_int64.pb')
-    session = Tensorflow::Session.new
-    session.extend_graph(graph)
-    inputs = Hash.new
-    inputs['input1'] = input1.tensor
-    inputs['input2'] = input2.tensor
-    result = session.run(inputs, ['output'], [])
-    expect(result[0]).to match_array([[8, 5], [7, 25]])
+describe "Tensorflow::Tensor" do
+  context 'adding integer tensors' do
+    it "Should Give correct results for adding two tensors." do
+      graph = Tensorflow::Graph.new
+      graph.read(File.dirname(__FILE__)+'/example_graphs/example_int64.pb')
+      session = Tensorflow::Session.new
+      session.extend_graph(graph)
+      inputs = {
+        'input1' => Tensorflow::Tensor.new([[1,2],[3,4]]).tensor,
+        'input2' => Tensorflow::Tensor.new([[7,3],[4,21]]).tensor,
+      }
+      result = session.run(inputs, ['output'], [])
+      expect(result[0]).to match_array([[8, 5], [7, 25]])
+    end
   end
 
-  it "Should make tensor of string data type." do
-    input1 = Tensorflow::Tensor.new(["Ruby", "Tensorflow", "is", "cool"],:string)
-    expect(["Ruby", "Tensorflow", "is", "cool"]).to match_array(Tensorflow::string_reader(input1.tensor))
+  context 'string tensor' do
+    it "Should make tensor of string data type." do
+      input1 = Tensorflow::Tensor.new(["Ruby", "Tensorflow", "is", "cool"], :string)
+      expect(["Ruby", "Tensorflow", "is", "cool"]).to match_array(Tensorflow::string_reader(input1.tensor))
+    end
   end
 end

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -10,23 +10,23 @@ describe "Variable" do
 
   it "sets a default name if none is specified" do
     no_name = graph.variable([1, 2, 3])
-    expect(no_name.ref.name).to eq("Variable:0")
+    expect(no_name.ref.name).to eq("Variable_0")
   end
 
   it "increments the default variable name for each unnamed variable" do
     no_name1 = graph.variable([1, 2, 3])
     no_name2 = graph.variable([4, 5, 6])
-    expect(no_name1.ref.name).to eq("Variable:0")
-    expect(no_name2.ref.name).to eq("Variable:1")
+    expect(no_name1.ref.name).to eq("Variable_0")
+    expect(no_name2.ref.name).to eq("Variable_1")
   end
 
   it "increments variable and constant names separately" do
     variable0 = graph.variable([0])
     constant0 = graph.constant([0])
     variable1 = graph.variable([1])
-    expect(variable0.ref.name).to eq("Variable:0")
-    expect(constant0.definition.name).to eq("Constant:0")
-    expect(variable1.ref.name).to eq("Variable:1")
+    expect(variable0.ref.name).to eq("Variable_0")
+    expect(constant0.definition.name).to eq("Constant_0")
+    expect(variable1.ref.name).to eq("Variable_1")
   end
 
   it "sets data type when it is specified" do


### PR DESCRIPTION
I began implementing [`tf.zeros`](https://www.tensorflow.org/versions/r0.10/api_docs/python/constant_op.html#zeros) (a special kind of constant-op  with all 0s – taking only shape as required argument) and found that our `constant()`-method doesn't work with scalars _and_ doesn't take `shape` as an argument. Writing specs for that, I _then_ discovered that our `default_names`- method uses a character, `:`, that makes it unretrievable from the TensorFlow graph. 

- `:` is not allowed in names on the actual (not the wrapper) TensorFlow graph
- make `constant()` compliant (https://www.tensorflow.org/versions/r0.10/api_docs/python/constant_op.html#constant), e.g. work on scalars and take `shape` as argument
- ... then build `zeros()`