### PR TITLE
minor readme + install tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ the following steps.
 
 #### Explicit dependencies
 
+- Ruby >= 2.2.0
 - [Bazel](http://www.bazel.io/docs/install.html)
 - [TensorFlow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/g3doc/get_started/os_setup.md)
 - [Swig](http://www.swig.org/download.html)
@@ -99,8 +100,9 @@ git clone https://github.com/somaticio/tensorflow.rb.git
 cd tensorflow.rb/ext/sciruby/tensorflow_c
 ruby extconf.rb
 make
-make install # Creates ../lib/ruby/site_ruby/X.X.X/<arch>/tf/Tensorflow.bundle (.so Linux)
+make install # Creates ../lib/ruby/site_ruby/X.X.X/<arch>/sciruby/Tensorflow.{bundle, so}
 cd ./../../..
+bundle install
 bundle exec rake install
 ```
 The last command is for installing the gem.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -259,6 +259,7 @@ ruby extconf.rb
 make
 make install # Creates ../lib/ruby/site_ruby/X.X.X/<arch>/tf/Tensorflow.bundle (.so Linux)
 cd ./../../..
+bundle install
 bundle exec rake install
 
 echo ""


### PR DESCRIPTION
I discovered that the codebase currently doesn't work for ruby < 2.2.
The main problem is that the CXXFLAGS variable was added to mkmf in 2.2,
which might be a fixable problem, but for now it's easier to just
require users to have >= 2.2.

This also adds a missing `bundle install` line to the install steps.