### PR TITLE
Fix a memory leak in session.run

### DIFF
--- a/lib/tensorflow/session.rb
+++ b/lib/tensorflow/session.rb
@@ -33,6 +33,9 @@ class Tensorflow::Session
     # On success, returns the fetched Tensors in the same order as supplied in
     # the fetches argument. If fetches is set to nil, the returned Tensor fetches
     # is empty.
+    #
+    # Note that the caller maintains responsibility for the input tensors, so 
+    # the caller should still call tensor.delete() on each input tensor
     def run(inputs, outputs, targets)
         inputPorts = Tensorflow::TF_Output_vector.new
         inputValues = Tensorflow::Tensor_Vector.new
@@ -57,6 +60,9 @@ class Tensorflow::Session
         outputValues.each do |value|
             converted_value = convert_value_for_output_array(value)
             output_array.push(converted_value)
+            # Since we're returning the results as an array, there's no point keeping
+            # the output tensor, so we delete it. 
+            Tensorflow::TF_DeleteTensor(value)
         end
         output_array
     end

--- a/lib/tensorflow/tensor.rb
+++ b/lib/tensorflow/tensor.rb
@@ -60,6 +60,13 @@ class Tensorflow::Tensor
                                                        dimension_data, rank, tensor_data, data_size * flatten.length)
     end
 
+    # Deletes the tensor which will also ensure that the tensor_deallocator function is called
+    # and the C++ memory is freed properly. A memory leak will occur anytime the ruby garbage collector
+    # deletes a tensor before this function is called.
+    def delete()
+        Tensorflow::TF_DeleteTensor(@tensor)
+    end
+
     #
     # Helper function to automatically set the data type of tensor.
     #


### PR DESCRIPTION
Previously, there way to properly delete tensor objects and free the C++
memory that is allocated in TF_NewTensor_wrapper.  This fix introduces a
delete function to tensor objects as well as providing a proper
deallocator function to the call to TF_NewTensor.