### PR TITLE
Fix the memory leak in Graph Importing

### DIFF
--- a/ext/sciruby/tensorflow_c/files/tf_tensor_helper.cc
+++ b/ext/sciruby/tensorflow_c/files/tf_tensor_helper.cc
@@ -22,6 +22,13 @@ void tensor_deallocator(void* data, size_t len, void* arg){
     free(data);
 }
 
+// Callback function for deallocating the data buffer that's created for 
+// importing a graph with buffer_read
+void buffer_deallocator(void* data, size_t length)
+{
+        delete[] data;
+}
+
 TF_Tensor* TF_NewTensor_wrapper(TF_DataType dtype, long long* dims, int num_dims,
                                 void* data, size_t len) {
         void* cData = malloc(len);
@@ -40,7 +47,10 @@ long long tensor_size(TF_Tensor* tensor)
 
 void buffer_read(TF_Buffer* tf_buffer, std::string file_string){
         int length = file_string.length();
+        (*tf_buffer).data_deallocator = &buffer_deallocator;
         (*tf_buffer).length = (size_t)length;
+        // This data is cleaned in the buffer_deallocator that's called when 
+        // TF_DeleteBuffer is called
         (*tf_buffer).data = new char[length];
         auto buffer_data_pointer = (*tf_buffer).data;
         for(int i = 0; i < length; i++) {

--- a/lib/tensorflow/graph.rb
+++ b/lib/tensorflow/graph.rb
@@ -42,6 +42,8 @@ class Tensorflow::Graph
         Tensorflow.buffer_read(buffer, CString(byte))
         status = Tensorflow::Status.new
         Tensorflow::TF_GraphImportGraphDef(self.c, buffer, opts, status.c)
+        Tensorflow::TF_DeleteImportGraphDefOptions(opts)
+        Tensorflow::TF_DeleteBuffer(buffer)
     end
 
     # Loads a graph stored in pb file into a graph def. This way you can define the graph

--- a/lib/tensorflow/op.rb
+++ b/lib/tensorflow/op.rb
@@ -33,7 +33,5 @@ end
 
 # A simple makeshift function to convert a ruby string to C++ string
 def CString(string)
-    vector = Tensorflow::String_Vector.new
-    vector[0] = string
-    vector[0]
+    String.new(string)
 end


### PR DESCRIPTION
The C++ bridge code for graph importing would leak the data buffer
that's used to import the graph.  This fix implements the proper buffer
deallocator function and calls delete buffer once a graph is loaded.