### PR TITLE
Fix a segfault in Session run

### DIFF
--- a/ext/sciruby/tensorflow_c/files/tf_tensor_helper.cc
+++ b/ext/sciruby/tensorflow_c/files/tf_tensor_helper.cc
@@ -182,6 +182,7 @@ std::vector<TF_Tensor *> TF_Tensor_vector_from_array(TF_Tensor** TF_Tensor_array
         return TF_Tensor_vector;
 };
 
+// Throws a SWIGValueError Exception if the call to run fails.  This will translate to a rb_eArgError exception in Ruby.
 std::vector<TF_Tensor *> Session_run(TF_Session* graph_session, std::vector<TF_Output > inputPorts, std::vector<TF_Tensor *> inputValues, std::vector<TF_Output > outputPorts, std::vector<TF_Operation *> cTargets)
 {
         auto status = TF_NewStatus();
@@ -226,7 +227,14 @@ std::vector<TF_Tensor *> Session_run(TF_Session* graph_session, std::vector<TF_O
         delete[] inputValues_array;
         delete[] outputValues_array;
         delete[] cTargets_array;
+        TF_Code status_code = TF_GetCode(status);
+        const char *message = TF_Message(status);
         TF_DeleteStatus(status);
+
+        if(status_code != TF_OK)
+        {
+           SWIG_exception(SWIG_ValueError, message);
+        }
 
         return TF_Tensor_vector;
 };

--- a/ext/sciruby/tensorflow_c/files/tf_tensor_helper.cc
+++ b/ext/sciruby/tensorflow_c/files/tf_tensor_helper.cc
@@ -306,8 +306,7 @@ std::string String_decoder(TF_Tensor* input_tensor){
         size_t dst_len;
         auto status = TF_NewStatus();
         auto offset_size = TF_StringDecode(src, length, &dst_str, &dst_len, status);
-        std::string out_string;
-        out_string += (char *) (dst_str);
+        std::string out_string(dst_str, dst_len);
         return out_string;
 }
 

--- a/lib/tensorflow/graph.rb
+++ b/lib/tensorflow/graph.rb
@@ -62,8 +62,12 @@ class Tensorflow::Graph
     # operation is present.
     def operation(name)
         c_operation = Tensorflow::TF_GraphOperationByName(c, CString(name))
-        warn("No Operation with the name #{name} exists.") if c_operation.nil?
-        Tensorflow::Operation.new(c_operation, self)
+        if c_operation.nil?
+            warn("No Operation with the name #{name} exists.")
+            nil
+        else
+            Tensorflow::Operation.new(c_operation, self)
+        end
     end
 
     # Adds a placeholder to the Graph, a placeholder is an

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -31,5 +31,11 @@ describe 'Operation' do
         const_1 = graph.constant(1.232, name: 'const1')
         expect(const_1.dataType).to match(2)   # TF_DOUBLE => 2
     end
+
+    it 'Should Test Nil Operation' do
+        graph = Tensorflow::Graph.new
+        operation = graph.operation('DOES_NOT_EXIST')
+        expect(operation).to match(nil)
+    end
     # TODO: Add Shape method and tests.
 end


### PR DESCRIPTION
Errors were ignored in the C++ implementation of Session_Run, which
meant that the ruby code could segfault as it would try to continue on
after a failed run.

This fix ensures Session_Run will throw an error that can be caught in
ruby to avoid segfaulting for cases like passing in a tensor with an
improper shape.