### PR TITLE
Fix missing null termination in tag list when loading a saved model

### DIFF
--- a/ext/sciruby/tensorflow_c/files/tf_tensor_helper.cc
+++ b/ext/sciruby/tensorflow_c/files/tf_tensor_helper.cc
@@ -259,17 +259,12 @@ TF_OperationDescription* input_list_helper(TF_OperationDescription* cdesc, TF_Ou
 }
 
 TF_Session* Saved_model_helper(TF_SessionOptions* cOpt, std::string cExportDir, std::vector<std::string> tags, TF_Graph* (graph_c),TF_Status* status_c){
-        char **tags_array;
-        tags_array = new char*[tags.size()];
+        const char* tags_array[tags.size()];
         for(auto i = 0; i < tags.size(); i++) {
-                tags_array[i] = new char[tags[i].length()];
-                for(auto j = 0; j < tags[i].length(); j++) tags_array[i][j] = tags[i][j];
+                tags_array[i] = tags[i].c_str();
         }
         const char* ExportDir = cExportDir.c_str();
         auto cSess = TF_LoadSessionFromSavedModel(cOpt, NULL, ExportDir,&tags_array[0], tags.size(), graph_c, NULL, status_c);
-        for(auto i = 0; i < tags.size(); i++) {
-                free(tags_array[i]);
-        }
         TF_DeleteSessionOptions(cOpt);
         return cSess;
 }


### PR DESCRIPTION
On one of our servers, we were seeing this behaviour:
```
2018-08-16 16:11:32.549690: I tensorflow/cc/saved_model/loader.cc:233] SavedModel load for tags { serve  }; Status: fail. Took 1261 microseconds.
```
Notice the extra space after 'serve'. This extra space was actually garbage data from Tensorflow converting the tag list from an array of chars, without null termination, to a string.

Using `c_str()` creates a correctly null-terminated array of chars and fixes the problem.

As a bonus, though my C++ is rusty, I believe this removes the need for the memory allocation/destruction with `new`.